### PR TITLE
Fix Object.groupBy compatibility issue in MySchedule component (fixes #17)

### DIFF
--- a/frontend/packages/volto-ploneconf/news/17.bugfix.md
+++ b/frontend/packages/volto-ploneconf/news/17.bugfix.md
@@ -1,0 +1,1 @@
+Fix Object.groupBy compatibility issue in MySchedule component that caused JavaScript errors in browsers that don't support this ES2024 feature. @Fosten

--- a/frontend/packages/volto-ploneconf/src/components/MyScheduleComponent/MyScheduleComponent.jsx
+++ b/frontend/packages/volto-ploneconf/src/components/MyScheduleComponent/MyScheduleComponent.jsx
@@ -61,17 +61,21 @@ const ScheduleBlock = ({ id, title, items, streamAction }) => {
 
 const groupByPeriod = (items) => {
   const now = Date.now();
-  const periods = Object.groupBy(items, (item) => {
+  const periods = { past: [], current: [], upcoming: [] };
+  
+  items.forEach((item) => {
     const start = item.start ? new Date(item.start) : null;
     const end = item.end ? new Date(item.end) : null;
+    
     if (end < now) {
-      return 'past';
+      periods.past.push(item);
     } else if (start <= now && now <= end) {
-      return 'current';
+      periods.current.push(item);
     } else {
-      return 'upcoming';
+      periods.upcoming.push(item);
     }
   });
+  
   return periods;
 };
 


### PR DESCRIPTION
This PR fixes the JavaScript error that occurs when navigating to the `/mySchedule` page after marking checkboxes.

## Problem
The issue was caused by the use of `Object.groupBy()` in the `MyScheduleComponent`, which is a very recent JavaScript method (ES2024) that is not yet widely supported in browsers. This caused a "Object.groupBy is not a function" error.

## Solution
- Replaced `Object.groupBy()` with a compatible implementation using `forEach()` and manual grouping
- Added changelog entry in the news directory following towncrier format

## Changes
- **Fixed**: Replaced `Object.groupBy()` with browser-compatible code in `MyScheduleComponent`
- **Added**: Changelog entry in `news/17.bugfix.md`

The fix ensures that the `/mySchedule` page works in all browsers, including those that don't yet support the newer `Object.groupBy()` method.

Fixes #17